### PR TITLE
Properly intialize and clean up XFConf library

### DIFF
--- a/src/clock_widget.c
+++ b/src/clock_widget.c
@@ -169,6 +169,9 @@ axisclock_destroy_plugin(AxisClockPlugin *axisclock)
         g_object_unref(axisclock->channel);
         axisclock->channel = NULL;
     }
+
+    /* Shut down XFConf library */
+    xfconf_shutdown();
     
     /* Free plugin structure */
     g_free(axisclock);

--- a/src/main.c
+++ b/src/main.c
@@ -66,6 +66,7 @@ axisclock_construct(XfcePanelPlugin *plugin)
     GError* error = NULL;
     if (!xfconf_init(&error)) {
         g_critical("Error initialising XFConf: %s", error ? error->message : "Unknown error");
+        if (error) g_error_free(error);
     }
     AxisClockPlugin *axisclock;
     

--- a/src/main.c
+++ b/src/main.c
@@ -62,7 +62,11 @@ axisclock_show_about(XfcePanelPlugin *plugin G_GNUC_UNUSED)
 /* Plugin constructor */
 static void
 axisclock_construct(XfcePanelPlugin *plugin)
-{
+{   
+    GError* error = NULL;
+    if (!xfconf_init(&error)) {
+        g_critical("Error initialising XFConf: %s", error ? error->message : "Unknown error");
+    }
     AxisClockPlugin *axisclock;
     
     /* Create the plugin */


### PR DESCRIPTION
Fix for issue #2 

According to https://developer.xfce.org/xfconf/xfconf-Xfconf-Library-Core.html it's required to first call `xfconf_init()` before using the xfconf library, and call `xfconf_shutdown()` after. Without this calls like xfconf_channel_get_string always return empty values, so fallback to the default. 

This PR adds those calls in the plugin constructor and cleanup functions, and this seems to fix the problem. You can confirm this by the appearance of key-value pairs in axisosclock in xfce4-settings-editor