### PR TITLE
Use font from configuration for display

### DIFF
--- a/src/clock_widget.c
+++ b/src/clock_widget.c
@@ -37,18 +37,18 @@
 void
 axisclock_update_time(AxisClockPlugin *axisclock)
 {
-    gchar *time_string;
+    gchar *markup;
     
     g_return_if_fail(axisclock != NULL);
     
-    /* Get formatted time */
-    time_string = axisclock_get_formatted_time(axisclock->config);
+    /* Get formatted time markup */
+    markup = axisclock_get_formatted_time_markup(axisclock->config);
     
     /* Update label */
-    gtk_label_set_text(GTK_LABEL(axisclock->label), time_string);
+    gtk_label_set_markup(GTK_LABEL(axisclock->label), markup);
     
     /* Free the string */
-    g_free(time_string);
+    g_free(markup);
 }
 
 /* Timeout callback for updating time */

--- a/src/time_formatter.c
+++ b/src/time_formatter.c
@@ -33,9 +33,9 @@
 #include "time_formatter.h"
 #include "plugin_config.h"
 
-/* Get the current time formatted according to configuration */
+/* Get the current time formatted and wrapped in font-style according to configuration */
 gchar *
-axisclock_get_formatted_time(PluginConfig *config)
+axisclock_get_formatted_time_markup(PluginConfig *config)
 {
     time_t current_time;
     struct tm *time_info;
@@ -73,6 +73,15 @@ axisclock_get_formatted_time(PluginConfig *config)
             memmove(p - 1, p, strlen(p) + 1);
         }
     }
+
+    gchar *markup;
+    const gchar *font = (config && config->font_name) ? config->font_name : "Sans 10";
+
+    markup = g_strdup_printf("<span font_desc=\"%s\">%s</span>", 
+                             font, formatted_time);
+
+    /* Ruim de tijdelijke formatted_time op */
+    g_free(formatted_time);
     
-    return formatted_time;
+    return markup;
 }

--- a/src/time_formatter.h
+++ b/src/time_formatter.h
@@ -33,7 +33,7 @@ G_BEGIN_DECLS
 #define AXISCLOCK_TIME_FORMAT "%a %b %-d %-l:%M%p"
 
 /* Function prototypes */
-gchar *axisclock_get_formatted_time(PluginConfig *config);
+gchar *axisclock_get_formatted_time_markup(PluginConfig *config);
 
 G_END_DECLS
 


### PR DESCRIPTION
This fixes/adds applying font-configuration to the widget label.

#### Notable changes
The easiest way to apply fonts to the label is by wrapping the label text in `<span font_desc="font family 10"> </span>`.
This pr changes `axisclock_get_formatted_time()` to `axisclock_get_formatted_time_markup()`.

And instead of calling `gtk_label_set_text()` we can call `gtk_label_set_markup()`. 
I've changed the names of some variables accordingly.